### PR TITLE
Synchronize changes with duffelhq

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.1 - 2025-01-15
+
+- Merge changes with `duffelhq`
+
 ## [0.4.0] - 2022-02-15
 
 - Use the latest API version, `v1`

--- a/README.md
+++ b/README.md
@@ -1,3 +1,12 @@
+> [!WARNING] 
+> This client library is not currently being supported by Duffel due to a lack of adoption.
+> 
+> You're welcome to fork the repositories and continue maintaining them for your own use.
+>
+> If, in the future, there's sufficient demand for a particular client library, we'll reconsider our decision to officially support it.
+
+---
+
 # Duffel API Ruby client library
 
 [![RubyDoc.info documentation](http://img.shields.io/badge/yard-docs-blue.svg)](https://rubydoc.info/github/duffelhq/duffel-api-ruby)

--- a/lib/duffel_api/version.rb
+++ b/lib/duffel_api/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module DuffelAPI
-  VERSION = "0.4.0"
+  VERSION = "0.4.1"
 end


### PR DESCRIPTION
Changes that apply are:

- Sync the repository with https://github.com/duffelhq/duffel-api-ruby/commits/main/
- Update version to 0.4.1

Finished in 2.19 seconds (files took 0.43387 seconds to load)
224 examples, 0 failures


